### PR TITLE
Handle case where body is empty string.

### DIFF
--- a/napalm_nxos/nxos.py
+++ b/napalm_nxos/nxos.py
@@ -339,8 +339,8 @@ class NXOSDriver(NetworkDriver):
             try:
                 string_output = self.device.show(command, fmat = 'json', text = True)[1]
                 dict_output   = eval(string_output)
-                s = dict_output.get('ins_api', {}).get('outputs', {}).get('output', {}).get('body', '')
-                cli_output[unicode(command)] = s
+                command_output = dict_output.get('ins_api', {}).get('outputs', {}).get('output', {}).get('body', '')
+                cli_output[unicode(command)] = command_output
             except Exception as e:
                 cli_output[unicode(command)] = 'Unable to execute command "{cmd}": {err}'.format(
                     cmd = command,

--- a/napalm_nxos/nxos.py
+++ b/napalm_nxos/nxos.py
@@ -79,7 +79,11 @@ class NXOSDriver(NetworkDriver):
 
     def _get_reply_body(self, result):
         # useful for debugging
-        return result.get('ins_api', {}).get('outputs', {}).get('output', {}).get('body', {})
+        ret = result.get('ins_api', {}).get('outputs', {}).get('output', {}).get('body', {})
+        # Original 'body' entry may have been an empty string, don't return that.
+        if not isinstance(ret, dict):
+            return {}
+        return ret
 
     def _get_reply_table(self, result, tablename, rowname):
         # still useful for debugging
@@ -335,7 +339,8 @@ class NXOSDriver(NetworkDriver):
             try:
                 string_output = self.device.show(command, fmat = 'json', text = True)[1]
                 dict_output   = eval(string_output)
-                cli_output[unicode(command)] = self._get_reply_body(dict_output)
+                s = dict_output.get('ins_api', {}).get('outputs', {}).get('output', {}).get('body', '')
+                cli_output[unicode(command)] = s
             except Exception as e:
                 cli_output[unicode(command)] = 'Unable to execute command "{cmd}": {err}'.format(
                     cmd = command,


### PR DESCRIPTION
Calling _get_command_table for ipv6 may return the following:

  {'ins_api': {'outputs': {'output': {'body': '', 'input': 'show ipv6 interface', ...

The 'body' entry here is an empty string, and so was not getting replaced with a dictionary
in the original code.  This patch ensures that a dictionary is returned.
