### PR TITLE
Fix optional_args port/protocol so works with https

### DIFF
--- a/napalm_nxos/nxos.py
+++ b/napalm_nxos/nxos.py
@@ -20,6 +20,7 @@ import re
 import tempfile
 from urllib2 import URLError
 from datetime import datetime
+import ssl
 
 # third party libs
 from netaddr import IPAddress
@@ -36,6 +37,8 @@ from napalm_base.base import NetworkDriver
 from napalm_base.exceptions import ConnectionException, MergeConfigException,\
                                    ReplaceConfigException, CommandErrorException
 
+# Allow untrusted SSL Certificates
+ssl._create_default_https_context = ssl._create_unverified_context
 
 def strip_trailing(string):
     lines = list(x.rstrip(' ') for x in string.splitlines())

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,6 +1,0 @@
-[pylama]
-linters = mccabe,pep257,pep8,pyflakes
-ignore = D203,
-
-[pylama:pep8]
-max_line_length = 120

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+pytest
+pytest-cov
+pytest-json
+pytest-pythonpath
+pylama
+flake8-import-order
+-r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-napalm-base
+napalm-base==0.17.0
 pycsco
-PyYAML # this is a requirement for pycsco but seems to be missing
+PyYAML  # this is a requirement for pycsco but seems to be missing
 netaddr

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[pylama]
+linters = mccabe,pep8,pyflakes
+ignore = D203,C901
+
+[pylama:pep8]
+max_line_length = 100


### PR DESCRIPTION
I allowed NAPALM Nexus to work with untrusted SSL certificates...so make sure you are okay with this.

Also fixed some other minor outstanding issues (since I was making a change). I tested this against a Nexus virtual device over SSL with an unsigned certificate. It wasn't working before I did this.

I also verified optional_args for both port and protocol.
