### PR TITLE
NXOS protocol param to standarized 'transport' param

### DIFF
--- a/napalm_nxos/nxos.py
+++ b/napalm_nxos/nxos.py
@@ -61,7 +61,8 @@ class NXOSDriver(NetworkDriver):
         if optional_args is None:
             optional_args = {}
 
-        self.transport = optional_args.get('nxos_protocol', 'http')
+        # nxos_protocol is there for backwards compatibility, transport is the preferred method
+        self.transport = optional_args.get('transport', optional_args.get('nxos_protocol', 'http'))
 
         if self.transport == 'https':
             self.port = optional_args.get('port', 443)

--- a/napalm_nxos/nxos.py
+++ b/napalm_nxos/nxos.py
@@ -62,7 +62,7 @@ class NXOSDriver(NetworkDriver):
             optional_args = {}
 
         # nxos_protocol is there for backwards compatibility, transport is the preferred method
-        self.transport = optional_args.get('transport', optional_args.get('nxos_protocol', 'http'))
+        self.transport = optional_args.get('transport', optional_args.get('nxos_protocol', 'https'))
 
         if self.transport == 'https':
             self.port = optional_args.get('port', 443)


### PR DESCRIPTION
Switch the optional argument `nxos_protocol` to the new, standarized `transport`

References:
* https://github.com/napalm-automation/napalm-ios/pull/159
* https://github.com/napalm-automation/napalm-ios/issues/132
* https://github.com/napalm-automation/napalm-eos/pull/167
