### PR TITLE
Additional rollback error check

### DIFF
--- a/napalm_nxos/nxos.py
+++ b/napalm_nxos/nxos.py
@@ -319,7 +319,7 @@ class NXOSDriver(NetworkDriver):
             return True
         except Exception:
             return False
-        if 'Rollback failed.' in rollback_result['msg']:
+        if 'Rollback failed.' in rollback_result['msg'] or 'ERROR' in output:
             raise ReplaceConfigException(rollback_result['msg'])
         return True
 


### PR DESCRIPTION

Was not catching this error, this fix may be to broad, but wanted to address in some way. 

```
NXOS1# rollback running file canidate_config.txt

ERROR: Rollback patch computation failed due to either of the following reasons
1. The checkpoint file was not created using CLI
2. The checkpoint file was created using nxos version earlier than 4.2.1

NXOS1#
```