### PR TITLE
Fix get_bgp_neighbors hard-coded with is_up: True and is_enabled: True

### DIFF
--- a/napalm_nxos/nxos.py
+++ b/napalm_nxos/nxos.py
@@ -458,12 +458,12 @@ class NXOSDriver(NetworkDriver):
                 state = py23_compat.text_type(neighbor_dict['state'])
 
                 bgp_state_dict = {
-                    'Idle': {'is_up': False, 'is_enabled': True, 'uptime': -1},
-                    'Active': {'is_up': False, 'is_enabled': True, 'uptime': -1},
-                    'Open': {'is_up': False, 'is_enabled': True, 'uptime': -1},
-                    'Established': {'is_up': True, 'is_enabled': True, 'uptime': 0},
-                    'Closing': {'is_up': True, 'is_enabled': True, 'uptime': 0},
-                    'Shutdown': {'is_up': False, 'is_enabled': False, 'uptime': -1},
+                    'Idle': {'is_up': False, 'is_enabled': True},
+                    'Active': {'is_up': False, 'is_enabled': True},
+                    'Open': {'is_up': False, 'is_enabled': True},
+                    'Established': {'is_up': True, 'is_enabled': True},
+                    'Closing': {'is_up': True, 'is_enabled': True},
+                    'Shutdown': {'is_up': False, 'is_enabled': False},
                 }
 
                 bgp_state = bgp_state_dict[state]

--- a/napalm_nxos/nxos.py
+++ b/napalm_nxos/nxos.py
@@ -437,6 +437,15 @@ class NXOSDriver(NetworkDriver):
 
     def get_bgp_neighbors(self):
         results = {}
+        bgp_state_dict = {
+            'Idle': {'is_up': False, 'is_enabled': True},
+            'Active': {'is_up': False, 'is_enabled': True},
+            'Open': {'is_up': False, 'is_enabled': True},
+            'Established': {'is_up': True, 'is_enabled': True},
+            'Closing': {'is_up': True, 'is_enabled': True},
+            'Shutdown': {'is_up': False, 'is_enabled': False},
+        }
+
         try:
             cmd = 'show bgp sessions vrf all'
             vrf_list = self._get_command_table(cmd, 'TABLE_vrf', 'ROW_vrf')
@@ -456,15 +465,6 @@ class NXOSDriver(NetworkDriver):
                 neighborid = napalm_base.helpers.ip(neighbor_dict['neighbor-id'])
                 remoteas = napalm_base.helpers.as_number(neighbor_dict['remoteas'])
                 state = py23_compat.text_type(neighbor_dict['state'])
-
-                bgp_state_dict = {
-                    'Idle': {'is_up': False, 'is_enabled': True},
-                    'Active': {'is_up': False, 'is_enabled': True},
-                    'Open': {'is_up': False, 'is_enabled': True},
-                    'Established': {'is_up': True, 'is_enabled': True},
-                    'Closing': {'is_up': True, 'is_enabled': True},
-                    'Shutdown': {'is_up': False, 'is_enabled': False},
-                }
 
                 bgp_state = bgp_state_dict[state]
 

--- a/napalm_nxos/nxos.py
+++ b/napalm_nxos/nxos.py
@@ -455,15 +455,27 @@ class NXOSDriver(NetworkDriver):
             for neighbor_dict in neighbors_list:
                 neighborid = napalm_base.helpers.ip(neighbor_dict['neighbor-id'])
                 remoteas = napalm_base.helpers.as_number(neighbor_dict['remoteas'])
+                state = py23_compat.text_type(neighbor_dict['state'])
+
+                bgp_state_dict = {
+                    'Idle': {'is_up': False, 'is_enabled': True, 'uptime': -1},
+                    'Active': {'is_up': False, 'is_enabled': True, 'uptime': -1},
+                    'Open': {'is_up': False, 'is_enabled': True, 'uptime': -1},
+                    'Established': {'is_up': True, 'is_enabled': True, 'uptime': 0},
+                    'Closing': {'is_up': True, 'is_enabled': True, 'uptime': 0},
+                    'Shutdown': {'is_up': False, 'is_enabled': False, 'uptime': -1},
+                }
+
+                bgp_state = bgp_state_dict[state]
 
                 result_peer_dict = {
                     'local_as': int(vrf_dict['local-as']),
                     'remote_as': remoteas,
                     'remote_id': neighborid,
-                    'is_enabled': True,
+                    'is_enabled': bgp_state['is_enabled'],
                     'uptime': -1,
-                    'description': py23_compat.text_type(''),
-                    'is_up': True
+                    'description': '',
+                    'is_up': bgp_state['is_up'],
                 }
                 result_peer_dict['address_family'] = {
                     'ipv4': {

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ skip = build/*,.tox/*
 [pylama:pep8]
 max_line_length = 100
 
-[pytest]
+[tool:pytest]
 addopts = --cov=napalm_nxos --cov-report term-missing -vs --pylama
 json_report = report.json
 jsonapi = true

--- a/test/unit/mocked_data/test_get_bgp_neighbors/normal/show_bgp_sessions_vrf_all.json
+++ b/test/unit/mocked_data/test_get_bgp_neighbors/normal/show_bgp_sessions_vrf_all.json
@@ -26,7 +26,7 @@
                     "lastflap": "P1M6DT17H23M26S",
                     "lastread": "PT0S",
                     "lastwrite": "PT0S",
-                    "state": "1"
+                    "state": "Established"
                 }
             }
         }, {
@@ -46,7 +46,7 @@
                     "lastflap": "P1M6DT17H23M26S",
                     "lastread": "PT0S",
                     "lastwrite": "PT0S",
-                    "state": "1"
+                    "state": "Established"
                 }
             }
         }]

--- a/test/unit/mocked_data/test_get_bgp_neighbors/nxosv_three_peers/expected_result.json
+++ b/test/unit/mocked_data/test_get_bgp_neighbors/nxosv_three_peers/expected_result.json
@@ -1,0 +1,55 @@
+{
+    "global": {
+        "router_id": "10.10.10.1", 
+        "peers": {
+            "10.99.99.2": {
+                "is_enabled": true, 
+                "uptime": -1, 
+                "remote_as": 22, 
+                "description": "", 
+                "remote_id": "10.99.99.2", 
+                "local_as": 22, 
+                "is_up": false, 
+                "address_family": {
+                    "ipv4": {
+                        "sent_prefixes": -1, 
+                        "accepted_prefixes": -1, 
+                        "received_prefixes": -1
+                    }
+                }
+            }, 
+            "1.1.1.1": {
+                "is_enabled": true, 
+                "uptime": -1, 
+                "remote_as": 33, 
+                "description": "", 
+                "remote_id": "1.1.1.1", 
+                "local_as": 22, 
+                "is_up": false, 
+                "address_family": {
+                    "ipv4": {
+                        "sent_prefixes": -1, 
+                        "accepted_prefixes": -1, 
+                        "received_prefixes": -1
+                    }
+                }
+            }, 
+            "10.20.20.2": {
+                "is_enabled": true, 
+                "uptime": -1, 
+                "remote_as": 22, 
+                "description": "", 
+                "remote_id": "10.20.20.2", 
+                "local_as": 22, 
+                "is_up": true, 
+                "address_family": {
+                    "ipv4": {
+                        "sent_prefixes": -1, 
+                        "accepted_prefixes": -1, 
+                        "received_prefixes": -1 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/unit/mocked_data/test_get_bgp_neighbors/nxosv_three_peers/show_bgp_sessions_vrf_all.json
+++ b/test/unit/mocked_data/test_get_bgp_neighbors/nxosv_three_peers/show_bgp_sessions_vrf_all.json
@@ -1,0 +1,57 @@
+{
+  "totalpeers": 3, 
+  "totalestablishedpeers": 1, 
+  "localas": 22, 
+  "TABLE_vrf": {
+    "ROW_vrf": {
+      "vrf-name-out": "default", 
+      "local-as": 22, 
+      "vrfpeers": 3, 
+      "vrfestablishedpeers": 1, 
+      "router-id": "10.10.10.1", 
+      "TABLE_neighbor": {
+        "ROW_neighbor": [
+          {
+            "neighbor-id": "1.1.1.1", 
+            "remoteas": 33, 
+            "connectionsdropped": 0, 
+            "lastflap": "P3DT29M9S", 
+            "lastread": "P1MT4H9M34S", 
+            "lastwrite": "P1MT4H9M34S", 
+            "state": "Idle", 
+            "localport": 0, 
+            "remoteport": 0, 
+            "notificationssent": 0, 
+            "notificationsreceived": 0
+          }, 
+          {
+            "neighbor-id": "10.20.20.2", 
+            "remoteas": 22, 
+            "connectionsdropped": 0, 
+            "lastflap": "PT2H4M28S", 
+            "lastread": "PT26S", 
+            "lastwrite": "PT25S", 
+            "state": "Established", 
+            "localport": 179, 
+            "remoteport": 53566, 
+            "notificationssent": 0, 
+            "notificationsreceived": 0
+          }, 
+          {
+            "neighbor-id": "10.99.99.2", 
+            "remoteas": 22, 
+            "connectionsdropped": 1, 
+            "lastflap": "PT2H56M3S", 
+            "lastread": "P1MT4H9M34S", 
+            "lastwrite": "P1MT4H9M34S", 
+            "state": "Idle", 
+            "localport": 0, 
+            "remoteport": 0, 
+            "notificationssent": 1, 
+            "notificationsreceived": 0
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Current implementation of get_bgp_neighbors is hard-coded to report is_up and is_enabled as always True...(not happy it was implemented this way).

Also the `uptime` and `prefixes` are hard-coded to '-1'. This only fixes the BGP state reporting. I will report separate issue on those.
