### PR TITLE
Fix file write bug

### DIFF
--- a/napalm_nxos_ssh/nxos_ssh.py
+++ b/napalm_nxos_ssh/nxos_ssh.py
@@ -512,7 +512,7 @@ class NXOSSSHDriver(NetworkDriver):
             msg = 'Could not transfer file. Not enough space on device.'
             raise ReplaceConfigException(msg)
 
-        self._check_file_exists(self.replace_file):
+        self._check_file_exists(self.replace_file)
         dest = os.path.basename(self.replace_file)
         full_remote_path = 'bootflash:{}'.format(dest)
         with paramiko.SSHClient() as ssh:


### PR DESCRIPTION
Current code duplicates the replace file contents due to a file write(). This removes this behavior.

I tested the compare_config, commit, discard_config, rollback operations.

I removed the `fix_checkpoint_string()` method as I thought writing the file was a bad idea (basically user will have to get checkpoint file properly.

I will duplicate this change in reunification branch.